### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: auth
           dockerfile: Dockerfile.prod


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore